### PR TITLE
issue #196

### DIFF
--- a/src/main/java/com/github/liaochong/myexcel/core/AbstractSimpleExcelBuilder.java
+++ b/src/main/java/com/github/liaochong/myexcel/core/AbstractSimpleExcelBuilder.java
@@ -641,10 +641,10 @@ abstract class AbstractSimpleExcelBuilder {
                     }
                     String defaultValue = defaultValueMap.get(field);
                     if (defaultValue != null) {
-                        return Pair.of(field.getType(), defaultValue);
+                        return Pair.of(String.class, defaultValue);
                     }
                     if (globalSetting.getDefaultValue() != null) {
-                        return Pair.of(field.getType(), globalSetting.getDefaultValue());
+                        return Pair.of(String.class, globalSetting.getDefaultValue());
                     }
                     return value;
                 })


### PR DESCRIPTION
问题：Date 类型的字段加 defaultValue 会报 ClassCastException 错误
修复：按照作者的指引把 Pair.of(field.getType(), defaultValue) 改成了 Pair.of(String.class, defaultValue)，还是作者对代码清楚，快速定位到问题

请提交至 **pre-release** 分支，勿直接提交至master分支。

请包含更改摘要以及修复的问题。还请包括相关的动机和背景。列出此更改所需的所有依赖项。

Please submit to the pre-release branch, do not submit directly to the master branch.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- [ ] Bug修复/Bug fix (non-breaking change which fixes an issue)
- [ ] 新特性/New feature (non-breaking change which adds functionality)
